### PR TITLE
Implement conversion of all maps in folder to PNG

### DIFF
--- a/MornaMapEditor/BatchConverter.cs
+++ b/MornaMapEditor/BatchConverter.cs
@@ -1,0 +1,9 @@
+﻿namespace MornaMapEditor
+{
+    public class BatchConverter
+    {
+        public static void ConvertMaps(string sourceFolder, string destinationFolder)
+        {
+        }
+    }
+}

--- a/MornaMapEditor/BatchConverter.cs
+++ b/MornaMapEditor/BatchConverter.cs
@@ -1,9 +1,50 @@
-﻿namespace MornaMapEditor
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MornaMapEditor
 {
     public class BatchConverter
     {
-        public static void ConvertMaps(string sourceFolder, string destinationFolder)
+        private IEnumerable<string> mapFilenames;
+        private ConcurrentDictionary<string, bool> mapNamesWritten = new ConcurrentDictionary<string, bool>();
+        private string destFolder;
+
+        public BatchConverter(string sourceFolder, string destinationFolder)
         {
+            destFolder = destinationFolder;
+            mapFilenames = Directory.GetFiles(sourceFolder).Where(s => s.EndsWith(".map") || s.EndsWith(".cmp"));
+        }
+
+        public int NumberToConvert()
+        {
+            return mapFilenames.Count();
+        }
+        public void ConvertMaps()
+        {
+            Parallel.ForEach(mapFilenames, (mapFilename) =>
+            {
+                var map = new Map(mapFilename);
+                var mapImage = map.GetRenderedMap(true, true);
+                var extension = Path.GetExtension(mapFilename).TrimStart('.');
+                lock (mapNamesWritten)
+                {
+                    if (mapNamesWritten.ContainsKey(map.Name))
+                    {
+                        ImageRenderer.Singleton.WriteImageToFile(mapImage, $"{destFolder}\\{map.Name}-{extension}.png");
+                        mapNamesWritten.TryAdd($"{map.Name}-{extension}", true);
+                    }
+                    else
+                    {
+                        ImageRenderer.Singleton.WriteImageToFile(mapImage, $"{destFolder}\\{map.Name}.png");
+                        mapNamesWritten.TryAdd(map.Name, true);
+                    }
+                }
+
+                mapImage.Dispose();
+            });
         }
     }
 }

--- a/MornaMapEditor/BatchConverterDialog.Designer.cs
+++ b/MornaMapEditor/BatchConverterDialog.Designer.cs
@@ -1,0 +1,173 @@
+﻿using System.ComponentModel;
+
+namespace MornaMapEditor
+{
+    partial class BatchConverterDialog
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.sourceFolder = new System.Windows.Forms.TextBox();
+            this.sourceButton = new System.Windows.Forms.Button();
+            this.destinationButton = new System.Windows.Forms.Button();
+            this.destinationFolder = new System.Windows.Forms.TextBox();
+            this.descriptionLabel = new System.Windows.Forms.Label();
+            this.sourceLabel = new System.Windows.Forms.Label();
+            this.destinationLabel = new System.Windows.Forms.Label();
+            this.okButton = new System.Windows.Forms.Button();
+            this.cancelButton = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            // 
+            // sourceFolder
+            // 
+            this.sourceFolder.Location = new System.Drawing.Point(144, 61);
+            this.sourceFolder.Name = "sourceFolder";
+            this.sourceFolder.ReadOnly = true;
+            this.sourceFolder.Size = new System.Drawing.Size(461, 20);
+            this.sourceFolder.TabIndex = 0;
+            // 
+            // sourceButton
+            // 
+            this.sourceButton.Location = new System.Drawing.Point(611, 61);
+            this.sourceButton.Name = "sourceButton";
+            this.sourceButton.Size = new System.Drawing.Size(82, 19);
+            this.sourceButton.TabIndex = 1;
+            this.sourceButton.Text = "Browse";
+            this.sourceButton.UseVisualStyleBackColor = true;
+            this.sourceButton.Click += new System.EventHandler(this.sourceButton_Click);
+            // 
+            // destinationButton
+            // 
+            this.destinationButton.Location = new System.Drawing.Point(611, 102);
+            this.destinationButton.Name = "destinationButton";
+            this.destinationButton.Size = new System.Drawing.Size(82, 19);
+            this.destinationButton.TabIndex = 3;
+            this.destinationButton.Text = "Browse\r\n";
+            this.destinationButton.UseVisualStyleBackColor = true;
+            this.destinationButton.Click += new System.EventHandler(this.destinationButton_Click);
+            // 
+            // destinationFolder
+            // 
+            this.destinationFolder.Location = new System.Drawing.Point(144, 102);
+            this.destinationFolder.Name = "destinationFolder";
+            this.destinationFolder.ReadOnly = true;
+            this.destinationFolder.Size = new System.Drawing.Size(461, 20);
+            this.destinationFolder.TabIndex = 2;
+            // 
+            // descriptionLabel
+            // 
+            this.descriptionLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
+            this.descriptionLabel.Location = new System.Drawing.Point(12, 11);
+            this.descriptionLabel.Name = "descriptionLabel";
+            this.descriptionLabel.Size = new System.Drawing.Size(492, 46);
+            this.descriptionLabel.TabIndex = 4;
+            this.descriptionLabel.Text = "Select Source and Destination Folders:";
+            // 
+            // sourceLabel
+            // 
+            this.sourceLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
+            this.sourceLabel.Location = new System.Drawing.Point(25, 61);
+            this.sourceLabel.Name = "sourceLabel";
+            this.sourceLabel.Size = new System.Drawing.Size(113, 20);
+            this.sourceLabel.TabIndex = 5;
+            this.sourceLabel.Text = "Source:";
+            this.sourceLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // destinationLabel
+            // 
+            this.destinationLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
+            this.destinationLabel.Location = new System.Drawing.Point(25, 102);
+            this.destinationLabel.Name = "destinationLabel";
+            this.destinationLabel.Size = new System.Drawing.Size(113, 20);
+            this.destinationLabel.TabIndex = 6;
+            this.destinationLabel.Text = "Destination:";
+            this.destinationLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // okButton
+            // 
+            this.okButton.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.okButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
+            this.okButton.Location = new System.Drawing.Point(267, 135);
+            this.okButton.Name = "okButton";
+            this.okButton.Size = new System.Drawing.Size(75, 23);
+            this.okButton.TabIndex = 7;
+            this.okButton.Text = "OK";
+            this.okButton.UseVisualStyleBackColor = true;
+            this.okButton.Click += new System.EventHandler(this.okButton_Click);
+            // 
+            // cancelButton
+            // 
+            this.cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.cancelButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
+            this.cancelButton.Location = new System.Drawing.Point(348, 135);
+            this.cancelButton.Name = "cancelButton";
+            this.cancelButton.Size = new System.Drawing.Size(75, 23);
+            this.cancelButton.TabIndex = 8;
+            this.cancelButton.Text = "Cancel";
+            this.cancelButton.UseVisualStyleBackColor = true;
+            // 
+            // BatchConverterDialog
+            // 
+            this.AcceptButton = this.okButton;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.cancelButton;
+            this.ClientSize = new System.Drawing.Size(705, 170);
+            this.Controls.Add(this.cancelButton);
+            this.Controls.Add(this.okButton);
+            this.Controls.Add(this.destinationLabel);
+            this.Controls.Add(this.sourceLabel);
+            this.Controls.Add(this.descriptionLabel);
+            this.Controls.Add(this.destinationButton);
+            this.Controls.Add(this.destinationFolder);
+            this.Controls.Add(this.sourceButton);
+            this.Controls.Add(this.sourceFolder);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "BatchConverterDialog";
+            this.ShowIcon = false;
+            this.ShowInTaskbar = false;
+            this.Text = "Convert Maps to png";
+            this.TopMost = true;
+            this.ResumeLayout(false);
+            this.PerformLayout();
+        }
+
+        private System.Windows.Forms.Button cancelButton;
+        private System.Windows.Forms.Label descriptionLabel;
+        private System.Windows.Forms.Button destinationButton;
+        private System.Windows.Forms.TextBox destinationFolder;
+        private System.Windows.Forms.Label destinationLabel;
+        private System.Windows.Forms.Button okButton;
+        private System.Windows.Forms.Button sourceButton;
+        private System.Windows.Forms.TextBox sourceFolder;
+        private System.Windows.Forms.Label sourceLabel;
+
+        #endregion
+    }
+}

--- a/MornaMapEditor/BatchConverterDialog.Designer.cs
+++ b/MornaMapEditor/BatchConverterDialog.Designer.cs
@@ -117,7 +117,6 @@ namespace MornaMapEditor
             this.okButton.TabIndex = 7;
             this.okButton.Text = "OK";
             this.okButton.UseVisualStyleBackColor = true;
-            this.okButton.Click += new System.EventHandler(this.okButton_Click);
             // 
             // cancelButton
             // 

--- a/MornaMapEditor/BatchConverterDialog.cs
+++ b/MornaMapEditor/BatchConverterDialog.cs
@@ -9,7 +9,7 @@ namespace MornaMapEditor
         public BatchConverterDialog()
         {
             InitializeComponent();
-            string defaultMapPath =
+            var defaultMapPath =
                 $"{Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)}\\NexusTK\\Maps";
             sourceFolder.Text = destinationFolder.Text =
                 Directory.Exists(defaultMapPath) ? defaultMapPath : Application.UserAppDataPath;
@@ -20,7 +20,7 @@ namespace MornaMapEditor
 
         private void sourceButton_Click(object sender, EventArgs e)
         {
-            FolderBrowserDialog browseDialog = new FolderBrowserDialog();
+            var browseDialog = new FolderBrowserDialog();
             browseDialog.Description = "Select Source Folder";
             browseDialog.RootFolder = Environment.SpecialFolder.MyComputer;
             browseDialog.SelectedPath = sourceFolder.Text;
@@ -34,7 +34,7 @@ namespace MornaMapEditor
 
         private void destinationButton_Click(object sender, EventArgs e)
         {
-            FolderBrowserDialog browseDialog = new FolderBrowserDialog();
+            var browseDialog = new FolderBrowserDialog();
             browseDialog.Description = "Select Destination Folder";
             browseDialog.RootFolder = Environment.SpecialFolder.MyComputer;
             browseDialog.SelectedPath = destinationFolder.Text;
@@ -44,11 +44,6 @@ namespace MornaMapEditor
             {
                 destinationFolder.Text = browseDialog.SelectedPath;
             }
-        }
-
-        private void okButton_Click(object sender, EventArgs e)
-        {
-            
         }
     }
 }

--- a/MornaMapEditor/BatchConverterDialog.cs
+++ b/MornaMapEditor/BatchConverterDialog.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.IO;
+using System.Windows.Forms;
+
+namespace MornaMapEditor
+{
+    public partial class BatchConverterDialog : Form
+    {
+        public BatchConverterDialog()
+        {
+            InitializeComponent();
+            string defaultMapPath =
+                $"{Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)}\\NexusTK\\Maps";
+            sourceFolder.Text = destinationFolder.Text =
+                Directory.Exists(defaultMapPath) ? defaultMapPath : Application.UserAppDataPath;
+        }
+
+        public TextBox SourceFolder => sourceFolder;
+        public TextBox DestinationFolder => destinationFolder;
+
+        private void sourceButton_Click(object sender, EventArgs e)
+        {
+            FolderBrowserDialog browseDialog = new FolderBrowserDialog();
+            browseDialog.Description = "Select Source Folder";
+            browseDialog.RootFolder = Environment.SpecialFolder.MyComputer;
+            browseDialog.SelectedPath = sourceFolder.Text;
+            browseDialog.ShowNewFolderButton = false;
+            DialogResult browseResult = browseDialog.ShowDialog();
+            if (browseResult == DialogResult.OK)
+            {
+                sourceFolder.Text = browseDialog.SelectedPath;
+            }
+        }
+
+        private void destinationButton_Click(object sender, EventArgs e)
+        {
+            FolderBrowserDialog browseDialog = new FolderBrowserDialog();
+            browseDialog.Description = "Select Destination Folder";
+            browseDialog.RootFolder = Environment.SpecialFolder.MyComputer;
+            browseDialog.SelectedPath = destinationFolder.Text;
+            browseDialog.ShowNewFolderButton = true;
+            DialogResult browseResult = browseDialog.ShowDialog();
+            if (browseResult == DialogResult.OK)
+            {
+                destinationFolder.Text = browseDialog.SelectedPath;
+            }
+        }
+
+        private void okButton_Click(object sender, EventArgs e)
+        {
+            
+        }
+    }
+}

--- a/MornaMapEditor/BatchConverterDialog.resx
+++ b/MornaMapEditor/BatchConverterDialog.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/MornaMapEditor/FormMain.Designer.cs
+++ b/MornaMapEditor/FormMain.Designer.cs
@@ -33,6 +33,7 @@
             this.menuStrip1 = new System.Windows.Forms.MenuStrip();
             this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.newMapToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.convertMapsToPNGsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem = new System.Windows.Forms.ToolStripSeparator();
             this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.editToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -65,7 +66,7 @@
             // 
             // fileToolStripMenuItem
             // 
-            this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {this.newMapToolStripMenuItem, this.toolStripMenuItem, this.exitToolStripMenuItem});
+            this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {this.newMapToolStripMenuItem, this.convertMapsToPNGsToolStripMenuItem, this.toolStripMenuItem, this.exitToolStripMenuItem});
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
             this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
             this.fileToolStripMenuItem.Text = "&File";
@@ -77,6 +78,13 @@
             this.newMapToolStripMenuItem.Size = new System.Drawing.Size(217, 22);
             this.newMapToolStripMenuItem.Text = "&New Map Window";
             this.newMapToolStripMenuItem.Click += new System.EventHandler(this.newMapToolStripMenuItem_Click);
+            // 
+            // convertMapsToPNGsToolStripMenuItem
+            // 
+            this.convertMapsToPNGsToolStripMenuItem.Name = "convertMapsToPNGsToolStripMenuItem";
+            this.convertMapsToPNGsToolStripMenuItem.Size = new System.Drawing.Size(217, 22);
+            this.convertMapsToPNGsToolStripMenuItem.Text = "Convert Maps to PNGs";
+            this.convertMapsToPNGsToolStripMenuItem.Click += new System.EventHandler(this.convertMapsToPNGsToolStripMenuItem_Click);
             // 
             // toolStripMenuItem
             // 
@@ -216,6 +224,7 @@
         }
 
         private System.Windows.Forms.ToolStripMenuItem aboutToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem convertMapsToPNGsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem editToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem exitToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem fileToolStripMenuItem;

--- a/MornaMapEditor/FormMain.cs
+++ b/MornaMapEditor/FormMain.cs
@@ -119,7 +119,7 @@ namespace MornaMapEditor
                     if (mdiChild is FormMap)
                     {
                         FormMap map = (FormMap)mdiChild;
-                        map.Reload(true);
+                        map.Reload();
                     }
                 }
             }
@@ -153,7 +153,7 @@ namespace MornaMapEditor
                     if (mdiChild is FormMap)
                     {
                         FormMap map = (FormMap)mdiChild;
-                        map.Reload(true);
+                        map.Reload();
                     }
                 }
             }
@@ -187,7 +187,7 @@ namespace MornaMapEditor
                     if (mdiChild is FormMap)
                     {
                         FormMap map = (FormMap)mdiChild;
-                        map.Reload(true);
+                        map.Reload();
                     }
                 }
             }

--- a/MornaMapEditor/FormMain.cs
+++ b/MornaMapEditor/FormMain.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Windows.Forms;
 
 namespace MornaMapEditor
@@ -213,6 +214,19 @@ namespace MornaMapEditor
             fTile = FormTile.GetFormInstance();
             fTile.WindowState = FormWindowState.Normal;
             fTile.Show();
+        }
+
+        private void convertMapsToPNGsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            BatchConverterDialog dialog = new BatchConverterDialog();
+            DialogResult result = dialog.ShowDialog();
+            if (result == DialogResult.OK)
+            {
+                BatchConverter.ConvertMaps(dialog.SourceFolder.Text, dialog.DestinationFolder.Text);
+                ProcessStartInfo startInfo = new ProcessStartInfo("explorer.exe", dialog.DestinationFolder.Text);
+                Process.Start(startInfo);
+                MessageBox.Show("Creation of map images comlete.");
+            }
         }
     }
 }

--- a/MornaMapEditor/FormMain.cs
+++ b/MornaMapEditor/FormMain.cs
@@ -218,14 +218,19 @@ namespace MornaMapEditor
 
         private void convertMapsToPNGsToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            BatchConverterDialog dialog = new BatchConverterDialog();
-            DialogResult result = dialog.ShowDialog();
+            var dialog = new BatchConverterDialog();
+            var result = dialog.ShowDialog();
             if (result == DialogResult.OK)
             {
-                BatchConverter.ConvertMaps(dialog.SourceFolder.Text, dialog.DestinationFolder.Text);
-                ProcessStartInfo startInfo = new ProcessStartInfo("explorer.exe", dialog.DestinationFolder.Text);
+                var converter = new BatchConverter(dialog.SourceFolder.Text, dialog.DestinationFolder.Text);
+                var fileCount = converter.NumberToConvert();
+                var confirmation =
+                    MessageBox.Show($@"{fileCount} Files will be converted, continue?", "Convesion Confirmation", MessageBoxButtons.YesNo);
+                if (confirmation != DialogResult.Yes) return;
+                converter.ConvertMaps();
+                var startInfo = new ProcessStartInfo("explorer.exe", dialog.DestinationFolder.Text);
                 Process.Start(startInfo);
-                MessageBox.Show("Creation of map images comlete.");
+                MessageBox.Show("Creation of map images complete.");
             }
         }
     }

--- a/MornaMapEditor/FormMap.Designer.cs
+++ b/MornaMapEditor/FormMap.Designer.cs
@@ -57,7 +57,6 @@
             this.showGridToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
             this.showMinimapToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.resizeWindowToDefaultToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.statusStrip = new System.Windows.Forms.StatusStrip();
             this.toolStripStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
             this.pnlImage = new System.Windows.Forms.PictureBox();
@@ -220,7 +219,7 @@
             // 
             // viewToolStripMenuItem
             // 
-            this.viewToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {this.showTilesToolStripMenuItem, this.showObjectsToolStripMenuItem, this.showPassToolStripMenuItem, this.toolStripSeparator2, this.showGridToolStripMenuItem, this.toolStripSeparator3, this.showMinimapToolStripMenuItem, this.resizeWindowToDefaultToolStripMenuItem});
+            this.viewToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {this.showTilesToolStripMenuItem, this.showObjectsToolStripMenuItem, this.showPassToolStripMenuItem, this.toolStripSeparator2, this.showGridToolStripMenuItem, this.toolStripSeparator3, this.showMinimapToolStripMenuItem});
             this.viewToolStripMenuItem.MergeAction = System.Windows.Forms.MergeAction.MatchOnly;
             this.viewToolStripMenuItem.Name = "viewToolStripMenuItem";
             this.viewToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
@@ -231,7 +230,7 @@
             this.showTilesToolStripMenuItem.CheckOnClick = true;
             this.showTilesToolStripMenuItem.Name = "showTilesToolStripMenuItem";
             this.showTilesToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F1;
-            this.showTilesToolStripMenuItem.Size = new System.Drawing.Size(328, 22);
+            this.showTilesToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
             this.showTilesToolStripMenuItem.Text = "Show &Tiles";
             this.showTilesToolStripMenuItem.Click += new System.EventHandler(this.showTilesToolStripMenuItem_Click);
             // 
@@ -240,7 +239,7 @@
             this.showObjectsToolStripMenuItem.CheckOnClick = true;
             this.showObjectsToolStripMenuItem.Name = "showObjectsToolStripMenuItem";
             this.showObjectsToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F2;
-            this.showObjectsToolStripMenuItem.Size = new System.Drawing.Size(328, 22);
+            this.showObjectsToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
             this.showObjectsToolStripMenuItem.Text = "Show O&bjects";
             this.showObjectsToolStripMenuItem.Click += new System.EventHandler(this.showObjectsToolStripMenuItem_Click);
             // 
@@ -249,45 +248,37 @@
             this.showPassToolStripMenuItem.CheckOnClick = true;
             this.showPassToolStripMenuItem.Name = "showPassToolStripMenuItem";
             this.showPassToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.F3;
-            this.showPassToolStripMenuItem.Size = new System.Drawing.Size(328, 22);
+            this.showPassToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
             this.showPassToolStripMenuItem.Text = "Show P&ass";
             this.showPassToolStripMenuItem.Click += new System.EventHandler(this.showPassToolStripMenuItem_Click);
             // 
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(325, 6);
+            this.toolStripSeparator2.Size = new System.Drawing.Size(188, 6);
             // 
             // showGridToolStripMenuItem
             // 
             this.showGridToolStripMenuItem.CheckOnClick = true;
             this.showGridToolStripMenuItem.Name = "showGridToolStripMenuItem";
             this.showGridToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys) ((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.G)));
-            this.showGridToolStripMenuItem.Size = new System.Drawing.Size(328, 22);
+            this.showGridToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
             this.showGridToolStripMenuItem.Text = "Show &Grid";
             this.showGridToolStripMenuItem.Click += new System.EventHandler(this.showGridToolStripMenuItem_Click);
             // 
             // toolStripSeparator3
             // 
             this.toolStripSeparator3.Name = "toolStripSeparator3";
-            this.toolStripSeparator3.Size = new System.Drawing.Size(325, 6);
+            this.toolStripSeparator3.Size = new System.Drawing.Size(188, 6);
             // 
             // showMinimapToolStripMenuItem
             // 
             this.showMinimapToolStripMenuItem.CheckOnClick = true;
             this.showMinimapToolStripMenuItem.Name = "showMinimapToolStripMenuItem";
             this.showMinimapToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys) ((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.I)));
-            this.showMinimapToolStripMenuItem.Size = new System.Drawing.Size(328, 22);
+            this.showMinimapToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
             this.showMinimapToolStripMenuItem.Text = "Show M&inimap";
             this.showMinimapToolStripMenuItem.Click += new System.EventHandler(this.showMinimapToolStripMenuItem_Click);
-            // 
-            // resizeWindowToDefaultToolStripMenuItem
-            // 
-            this.resizeWindowToDefaultToolStripMenuItem.Name = "resizeWindowToDefaultToolStripMenuItem";
-            this.resizeWindowToDefaultToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys) (((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) | System.Windows.Forms.Keys.R)));
-            this.resizeWindowToDefaultToolStripMenuItem.Size = new System.Drawing.Size(328, 22);
-            this.resizeWindowToDefaultToolStripMenuItem.Text = "Resize Window to Default (17 x 15)";
-            this.resizeWindowToDefaultToolStripMenuItem.Click += new System.EventHandler(this.resizeWindowToDefaultToolStripMenuItem_Click);
             // 
             // statusStrip
             // 
@@ -347,6 +338,7 @@
             this.DoubleBuffered = true;
             this.Icon = ((System.Drawing.Icon) (resources.GetObject("$this.Icon")));
             this.Name = "FormMap";
+            this.ShowIcon = false;
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FormMap_FormClosing);
             this.menuStrip.ResumeLayout(false);
             this.menuStrip.PerformLayout();
@@ -372,7 +364,6 @@
         internal System.Windows.Forms.PictureBox pnlImage;
         private System.Windows.Forms.ToolStripMenuItem redoToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem resizeMapToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem resizeWindowToDefaultToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem saveAsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem savePngToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem saveToolStripMenuItem;

--- a/MornaMapEditor/FormMap.cs
+++ b/MornaMapEditor/FormMap.cs
@@ -749,7 +749,6 @@ namespace MornaMapEditor
                                 var renderedTile = activeMap.GetFullyRenderedTile(mapTileX, mapTileY - i, sizeModifier,
                                     activeMap[mapTileX, mapTileY].ObjectNumber == 0, showTiles, showObjects);
                                 graphics.DrawImage(renderedTile, mapTileX * sizeModifier, (mapTileY - i) * sizeModifier);
-                                renderedTile.Dispose();
                             }
                         }
                     }
@@ -758,7 +757,6 @@ namespace MornaMapEditor
                         var renderedTile = activeMap.GetFullyRenderedTile(mapTileX, mapTileY, sizeModifier,
                             activeMap[mapTileX, mapTileY].TileNumber == 0, showTiles, showObjects);
                         graphics.DrawImage(renderedTile, mapTileX * sizeModifier, mapTileY * sizeModifier);
-                        renderedTile.Dispose();
                     }
                 }
             }

--- a/MornaMapEditor/FormMap.cs
+++ b/MornaMapEditor/FormMap.cs
@@ -15,13 +15,7 @@ namespace MornaMapEditor
         public FormMinimap MinimapWindow { get; private set; }
         public bool IsMinimapVisible { get; private set; }
 
-        private Bitmap bitmap;
-        private Bitmap mapBitmap;
-        private Bitmap tileBitmap;
-        private Bitmap objectBitmap;
-        private static Thread renderThread;
         private static int untitledMapIndex;
-        private bool mapBitmapIsReady;
         private bool showTiles, showObjects;
         private bool isMouseDown;
         private bool copy;
@@ -37,6 +31,8 @@ namespace MornaMapEditor
         private int yMaxFill;
         private int saveCheck = 0;
 
+        private bool changeSinceRender;
+        
         private readonly LinkedList<IMapAction> mapUndoActions = new LinkedList<IMapAction>();
         private readonly LinkedList<IMapAction> mapRedoActions = new LinkedList<IMapAction>();
 
@@ -44,7 +40,11 @@ namespace MornaMapEditor
         public bool ShowGrid
         {
             get { return showGrid; }
-            set { showGrid = value; pnlImage.Invalidate(); }
+            set { 
+                showGrid = value;             
+                changeSinceRender = true;
+                Invalidate(); 
+            }
         }
 
         private Point lastPassToggled = new Point(-1, -1);
@@ -52,7 +52,11 @@ namespace MornaMapEditor
         public bool ShowPass
         {
             get { return showPass; }
-            set { showPass = value; pnlImage.Invalidate(); }
+            set { 
+                showPass = value; 
+                changeSinceRender = true;
+                Invalidate(); 
+            }
         }
 
         public FormMap(Form mdiParent)
@@ -66,13 +70,13 @@ namespace MornaMapEditor
             //pnlImage.Paint += pnlImage_Paint;
 
             showMinimapToolStripMenuItem.PerformClick();
-            resizeWindowToDefaultToolStripMenuItem.PerformClick();
             showTilesToolStripMenuItem.Checked = true;
             showTiles = showTilesToolStripMenuItem.Checked;
             showObjectsToolStripMenuItem.Checked = true;
             showObjects = showObjectsToolStripMenuItem.Checked;
 
-            Reload(false);
+            sizeModifier = ImageRenderer.Singleton.sizeModifier;
+            
             CreateNewMapCore(initialWidth, initialHeight);
 
             MinimapWindow.FormClosing += MinimapWindow_FormClosing;
@@ -95,18 +99,13 @@ namespace MornaMapEditor
             e.Cancel = true;
         }
 
-        private void SetImage(Image image)
-        {
-            if (pnlImage.Image != null) pnlImage.Image.Dispose();
-            pnlImage.Image = image != null ? new Bitmap(image, pnlImage.Width, pnlImage.Height) : null;
-        }
-
         #region Form event handlers
 
         private void pnlImage_Paint(object sender, PaintEventArgs e)
         {
-            //OnPaint(e);
-
+            if (!changeSinceRender)
+                return;
+            e.Graphics.DrawImage(pnlImage.Image, 0, 0);
             if (ShowGrid)
             {
                 Pen penGrid = new Pen(Color.LightCyan, 1);
@@ -153,16 +152,6 @@ namespace MornaMapEditor
                 e.Graphics.DrawRectangle(pen, focusedTile.X * sizeModifier, focusedTile.Y * sizeModifier, sizeModifier, sizeModifier);
                 pen.Dispose();
             }
-
-
-            if (pnlImage.Image == null && mapBitmapIsReady)
-            {
-                pnlImage.Image = mapBitmap;
-                pnlImage.Invalidate();
-                UpdateMinimap(true, true);
-            }
-
-
         }
 
         private void FormMap_MouseWheel(object sender, MouseEventArgs e)
@@ -269,10 +258,9 @@ namespace MornaMapEditor
                             activeMap[x, y].TileNumber = TileManager.TileSelection[new Point(0, 0)];
                         }
                     }
-
-                    SetImage(null);
-                    RenderMap();
-
+                    activeMap.IsModified = changeSinceRender = true;
+                    pnlImage.Image = activeMap.GetRenderedMap(showTiles, showObjects);
+                    Invalidate();
                 }
             }
 
@@ -302,8 +290,9 @@ namespace MornaMapEditor
                     {
                         floodFill(tileX, tileY, activeMap[tileX, tileY].TileNumber, TileManager.TileSelection[new Point(0, 0)]);
                     }
-                    //SetImage(null);
-                    //RenderMap();
+                    activeMap.IsModified = changeSinceRender = true;
+                    pnlImage.Image = activeMap.GetRenderedMap(showTiles, showObjects);
+                    Invalidate();
                 }
 
             }
@@ -393,8 +382,8 @@ namespace MornaMapEditor
                 MinimapWindow.FormClosing -= MinimapWindow_FormClosing;
                 MinimapWindow.SelectionChanged -= MinimapWindow_SelectionChanged;
                 MinimapWindow.SetImage(null);
-                SetImage(null);
                 MinimapWindow.Close();
+                pnlImage.Image?.Dispose();
                 GC.Collect();
             }
         }
@@ -480,7 +469,9 @@ namespace MornaMapEditor
 
             mapRedoActions.AddLast(lastAction); // to be able to redo what has been undone
             lastAction.Undo(activeMap);
-            RefreshMapActionUI(lastAction);
+            activeMap.IsModified = changeSinceRender = true;
+            pnlImage.Image = activeMap.GetRenderedMap(showTiles, showObjects);
+            Invalidate();
         }
 
         private void redoToolStripMenuItem_Click(object sender, EventArgs e)
@@ -491,7 +482,9 @@ namespace MornaMapEditor
 
             mapUndoActions.AddLast(lastAction); // to be able to undo what has been redone
             lastAction.Redo(activeMap);
-            RefreshMapActionUI(lastAction);
+            activeMap.IsModified = changeSinceRender = true;
+            pnlImage.Image = activeMap.GetRenderedMap(showTiles, showObjects);
+            Invalidate();
         }
 
         private void editableToolStripMenuItem_Click(object sender, EventArgs e)
@@ -515,10 +508,9 @@ namespace MornaMapEditor
             AddMapAction(new MapActionResize(activeMap.Size, mapSizeDialog.MapSize));
 
             activeMap.Size = mapSizeDialog.MapSize;
-            activeMap.IsModified = true;
-            SetImage(null);
-            RenderMap();
-            //UpdateMinimap(true, true);
+            activeMap.IsModified = changeSinceRender = true;
+            pnlImage.Image = activeMap.GetRenderedMap(showTiles, showObjects);
+            Invalidate();
         }
 
         private void copySectionToolStripMenuItem_Click(object sender, EventArgs e)
@@ -536,38 +528,35 @@ namespace MornaMapEditor
         private void showTilesToolStripMenuItem_Click(object sender, EventArgs e)
         {
             showTiles = showTilesToolStripMenuItem.Checked;
-            SetImage(null);
-            RenderMap();
-            //UpdateMinimap(true, false);
+            changeSinceRender = true;
+            pnlImage.Image = activeMap.GetRenderedMap(showTiles, showObjects);
+            Invalidate();
         }
 
         private void showObjectsToolStripMenuItem_Click(object sender, EventArgs e)
         {
             showObjects = showObjectsToolStripMenuItem.Checked;
-            SetImage(null);
-            RenderMap();
-            //UpdateMinimap(true, false);
+            changeSinceRender = true;
+            pnlImage.Image = activeMap.GetRenderedMap(showTiles, showObjects);
+            Invalidate();
         }
 
         private void showPassToolStripMenuItem_Click(object sender, EventArgs e)
         {
             ShowPass = showPassToolStripMenuItem.Checked;
+            changeSinceRender = true;
+            Invalidate();
         }
 
         private void showGridToolStripMenuItem_Click(object sender, EventArgs e)
         {
             ShowGrid = showGridToolStripMenuItem.Checked;
-        }
-
-        private void resizeWindowToDefaultToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            SetClientSizeCore(initialWidth * sizeModifier, initialHeight * sizeModifier + 22);
+            changeSinceRender = true;
+            Invalidate();
         }
 
         #endregion
-
-        #region Helper methods
-
+        
         private DialogResult SaveCheck()
         {
             if (!activeMap.IsModified) return DialogResult.OK;
@@ -595,11 +584,12 @@ namespace MornaMapEditor
             string mapName = "UntitledMap" + untitledMapIndex++;
             activeMap.Name = mapName;
             Text = string.Format(@"Map [{0}]", mapName);
-            SetImage(null);
             editableToolStripMenuItem.Checked = activeMap.IsEditable;
-            RenderMap();
             mapUndoActions.Clear();
             mapRedoActions.Clear();
+            changeSinceRender = true;
+            pnlImage.Image = activeMap.GetRenderedMap(showTiles, showObjects);
+            Invalidate();
             //UpdateMinimap(true, true);
         }
 
@@ -624,11 +614,12 @@ namespace MornaMapEditor
             {
                 activeMap = new Map(activeMapPath);
                 Text = string.Format("Map [{0}]", activeMap.Name);
-                SetImage(null);
                 editableToolStripMenuItem.Checked = activeMap.IsEditable;
-                RenderMap();
                 mapUndoActions.Clear();
                 mapRedoActions.Clear();
+                changeSinceRender = true;
+                pnlImage.Image = activeMap.GetRenderedMap(showTiles, showObjects);
+                Invalidate();
                 //UpdateMinimap(true, true);
             }
             catch (Exception ex)
@@ -700,23 +691,6 @@ namespace MornaMapEditor
             return dictionary;
         }
 
-        private void replaceTile(Tile oldTile, Tile newTile)
-        {
-            TileManager.SelectionType pasteSelection = new TileManager.SelectionType();
-
-            for (int x = 0; x <= activeMap.Size.Width; x++)
-            {
-                for (int y = 0; y <= activeMap.Size.Width; y++)
-                {
-                    if ((activeMap[x, y] ?? Tile.DefaultTile) == oldTile)
-                    {
-                        Paste(x, y, pasteSelection);
-                    }
-                }
-            }
-
-        }
-
         private void Paste(int tileX, int tileY, TileManager.SelectionType selectionType)
         {
             Dictionary<Point, int> selection;
@@ -724,6 +698,8 @@ namespace MornaMapEditor
             else if (selectionType == TileManager.SelectionType.Pass) selection = TileManager.PassSelection;
             else if (selectionType == TileManager.SelectionType.Tile) selection = TileManager.TileSelection;
             else return;
+
+            var graphics = Graphics.FromImage(pnlImage.Image);
 
             foreach (KeyValuePair<Point, int> keyValuePair in selection)
             {
@@ -768,17 +744,28 @@ namespace MornaMapEditor
                     {
                         for (int i = 0; i < 12; i++)
                         {
-                            if (mapTileY - i >= 0) RenderSingleMapTile(mapTileX, mapTileY - i, activeMap[mapTileX, mapTileY].ObjectNumber == 0);
+                            if (mapTileY - i >= 0)
+                            {
+                                var renderedTile = activeMap.GetFullyRenderedTile(mapTileX, mapTileY - i, sizeModifier,
+                                    activeMap[mapTileX, mapTileY].ObjectNumber == 0, showTiles, showObjects);
+                                graphics.DrawImage(renderedTile, mapTileX * sizeModifier, (mapTileY - i) * sizeModifier);
+                                renderedTile.Dispose();
+                            }
                         }
-                        pnlImage.Invalidate();
                     }
                     else
-                    {
-                        RenderSingleMapTile(mapTileX, mapTileY, activeMap[mapTileX, mapTileY].TileNumber == 0);
-                        pnlImage.Invalidate();
+                    {                                
+                        var renderedTile = activeMap.GetFullyRenderedTile(mapTileX, mapTileY, sizeModifier,
+                            activeMap[mapTileX, mapTileY].TileNumber == 0, showTiles, showObjects);
+                        graphics.DrawImage(renderedTile, mapTileX * sizeModifier, mapTileY * sizeModifier);
+                        renderedTile.Dispose();
                     }
                 }
             }
+            graphics.Dispose();
+            activeMap.IsModified = changeSinceRender = true;
+            pnlImage.Image = activeMap.GetRenderedMap(showTiles, showObjects);
+            Invalidate();
         }
 
         private void TogglePass(int tileX, int tileY)
@@ -792,8 +779,8 @@ namespace MornaMapEditor
 
             activeMap.IsModified = true;
             AddMapAction(new MapActionPastePass(new Point(tileX, tileY), (activeMap[tileX, tileY].Passable ? 0 : 1)));
-            pnlImage.Invalidate();
-            //RenderSingleMapTile(tileX, tileY, activeMap[tileX, tileY].TileNumber == 0);
+            activeMap.IsModified = changeSinceRender = true;
+            Refresh();
         }
 
         public void floodFill(int fillX, int fillY, int findTile, int replaceTile)
@@ -808,8 +795,6 @@ namespace MornaMapEditor
             if (fillX - 1 >= xMinFill) { floodFill(fillX - 1, fillY, findTile, replaceTile); }
             if (fillY + 1 < yMaxFill) { floodFill(fillX, fillY + 1, findTile, replaceTile); }
             if (fillY - 1 >= yMinFill) { floodFill(fillX, fillY - 1, findTile, replaceTile); }
-            return;
-
         }
 
         private void AddMapAction(IMapAction mapAction)
@@ -817,14 +802,6 @@ namespace MornaMapEditor
             if (mapUndoActions.Count > 1000) for (int i = 0; i < 100; i++) mapUndoActions.RemoveFirst();
             mapUndoActions.AddLast(mapAction);
             mapRedoActions.Clear();
-        }
-
-        public void Reload(bool render)
-        {
-            sizeModifier = ImageRenderer.Singleton.sizeModifier;
-            SetImage(null);
-            resizeWindowToDefaultToolStripMenuItem.PerformClick();
-            if (render) RenderMap();
         }
 
         private void tmrSave_Tick(object sender, EventArgs e)
@@ -840,182 +817,12 @@ namespace MornaMapEditor
             else if (saveCheck == 15) saveToolStripMenuItem.PerformClick();
         }
 
-        #endregion
-
-        #region Rendering
-
-        private void RefreshMapActionUI(IMapAction lastAction)
+        public void Reload()
         {
-            activeMap.IsModified = true;
-
-            if (lastAction is MapActionResize)
-            {
-                SetImage(null);
-                RenderMap();
-                //UpdateMinimap(true, true);
-            }
-            if (lastAction is MapActionPasteTile || lastAction is MapActionPastePass)
-            {
-                Tile tile = activeMap[lastAction.Tile.X, lastAction.Tile.Y];
-                RenderSingleMapTile(lastAction.Tile.X, lastAction.Tile.Y, tile == null || tile.TileNumber == 0);
-                pnlImage.Invalidate();
-                UpdateMinimap(true, false);
-            }
-            else if (lastAction is MapActionPasteObject)
-            {
-                Tile tile = activeMap[lastAction.Tile.X, lastAction.Tile.Y];
-                for (int i = 0; i < 12; i++)
-                {
-                    if (lastAction.Tile.Y - i >= 0)
-                        RenderSingleMapTile(lastAction.Tile.X, lastAction.Tile.Y - i,
-                                            tile == null || tile.ObjectNumber == 0);
-                }
-                pnlImage.Invalidate();
-                UpdateMinimap(true, false);
-            }
+            sizeModifier = ImageRenderer.Singleton.sizeModifier;
+            changeSinceRender = true;
+            pnlImage.Image = activeMap.GetRenderedMap(showTiles, showObjects);
+            Invalidate();
         }
-
-        private void RenderMap()
-        {
-            //Bitmap mapBitmap;
-            if (pnlImage.Image == null)
-            {
-                int imageWidth = activeMap.Size.Width * sizeModifier;
-                int imageHeight = activeMap.Size.Height * sizeModifier;
-                mapBitmap = new Bitmap(imageWidth, imageHeight);
-            }
-            //else mapBitmap = (Bitmap) pnlImage.Image;
-
-            if (!showObjects && !showTiles)
-            {
-                mapBitmap = new Bitmap(activeMap.Size.Width * sizeModifier, activeMap.Size.Height * sizeModifier);
-                pnlImage.Image = mapBitmap;
-                return;
-            }
-
-            renderThread = new Thread(new ThreadStart(RenderLoop));
-            renderThread.Start();
-            renderThread.Join();
-            //ThreadPool.QueueUserWorkItem(o => RenderLoop());
-            //for (int x = 0; x < activeMap.Size.Width; x++)
-            //{
-            //    for (int y = 0; y < activeMap.Size.Height; y++)
-            //    {
-            //        // Debug.WriteLine("x,y:  " + x + "," + y); // testing
-            //        new Thread(o => RenderSingleMapTile(x, y, g, false)).Start();
-            //    }
-            //}
-
-            //g.Dispose();
-            //panel1.AutoScrollMinSize = pnlImage.Image.Size;
-            //pnlImage.Invalidate();
-            //picMap.Image = mapBitmap;
-            //Application.DoEvents();
-            //tSet.Dispose();
-        }
-
-        private void RenderLoop()
-        {
-            mapBitmapIsReady = false;
-            Graphics g = Graphics.FromImage(mapBitmap);
-            g.Clear(Color.DarkGreen);
-
-            for (int x = 0; x < activeMap.Size.Width; x++)
-            {
-                for (int y = 0; y < activeMap.Size.Height; y++)
-                {
-                    RenderSingleMapTile(x, y, g, false);
-                }
-            }
-
-            g.Dispose();
-            mapBitmapIsReady = true;
-            pnlImage.Invalidate();
-            MinimapWindow.pnlImage.Invalidate();
-
-        }
-
-        private void RenderSingleMapTile(int x, int y, bool forceRenderEmpty)
-        {
-            //Image mapImage = picMap.Image;
-            Graphics g = Graphics.FromImage(pnlImage.Image);
-            RenderSingleMapTile(x, y, g, forceRenderEmpty);
-            g.Dispose();
-            //picMap.Image = mapImage;
-            //picMap.Refresh();
-        }
-
-        private void RenderSingleMapTile(int x, int y, Graphics g, bool forceRenderEmpty)
-        {
-            tileBitmap = GetTileBitmap(x, y);
-            objectBitmap = GetObjectBitmap(x, y);
-            if (forceRenderEmpty)
-            {
-                Bitmap bitmapClear = new Bitmap(sizeModifier, sizeModifier);
-                Graphics gClear = Graphics.FromImage(bitmapClear);
-                gClear.Clear(Color.DarkGreen);
-
-                if (objectBitmap == null)
-                {
-                    if (tileBitmap == null) objectBitmap = bitmapClear;
-                    if (tileBitmap != null) objectBitmap = new Bitmap(sizeModifier, sizeModifier);
-                }
-                if (tileBitmap == null) tileBitmap = bitmapClear;
-                gClear.Dispose();
-                //bitmapClear.Dispose();
-            }
-
-            // Only tile
-            if (showTiles && tileBitmap != null && (!showObjects || objectBitmap == null))
-                g.DrawImage(tileBitmap, x * sizeModifier, y * sizeModifier);//, 36, 36);
-
-            // Only object
-            else if (showObjects && objectBitmap != null && (!showTiles || tileBitmap == null))
-            {
-                //If only showing objects, make sure we have a background of dark green first
-                g.FillRectangle(Brushes.DarkGreen, x * sizeModifier, y * sizeModifier, sizeModifier, sizeModifier);
-                g.DrawImage(objectBitmap, x * sizeModifier, y * sizeModifier); //, 36, 36);
-            }
-
-            // Both
-            else if (showTiles && showObjects)
-            {
-                if (objectBitmap != null && tileBitmap != null)
-                {
-                    Graphics tileGraphics = Graphics.FromImage(tileBitmap);
-                    tileGraphics.DrawImage(objectBitmap, 0, 0);
-                    //tileGraphics.Dispose();
-                    g.DrawImage(tileBitmap, x * sizeModifier, y * sizeModifier);//, 36, 36);
-                    tileGraphics.Dispose();
-                }
-            }
-            //if (tileBitmap != null) tileBitmap.Dispose();
-            //if (objectBitmap != null) objectBitmap.Dispose();
-        }
-
-        private Bitmap GetTileBitmap(int x, int y)
-        {
-            return !showTiles ? null : activeMap[x, y]?.RenderTile();
-        }
-
-        private Bitmap GetObjectBitmap(int x, int y)
-        {
-            if (!showObjects) return null;
-            
-            bitmap = new Bitmap(sizeModifier, sizeModifier);
-            Graphics graphics = Graphics.FromImage(bitmap);
-            if (tileBitmap == null) graphics.Clear(Color.DarkGreen);
-            
-            Tile[] tilesWithPossibleObjects = new Tile[12]; 
-            for (int i = 0; i < 12; i++)
-            {
-                if ((i + y) >= activeMap.Size.Height) break;
-                tilesWithPossibleObjects[i] = activeMap[x, y + i];
-            }
-            
-            return activeMap[x, y]?.RenderObjects(tilesWithPossibleObjects);
-        }
-
-        #endregion
     }
 }

--- a/MornaMapEditor/FormMap.cs
+++ b/MornaMapEditor/FormMap.cs
@@ -1000,40 +1000,6 @@ namespace MornaMapEditor
 
         private Bitmap GetObjectBitmap(int x, int y)
         {
-            // if (!showObjects) return null;
-            //
-            // bitmap = new Bitmap(sizeModifier, sizeModifier);
-            // Graphics graphics = Graphics.FromImage(bitmap);
-            // if (tileBitmap == null) graphics.Clear(Color.DarkGreen);
-            //
-            // for (int i = 0; i < 12; i++)
-            // {
-            //     if ((i + y) >= activeMap.Size.Height) break;
-            //
-            //     Tile mapTile = activeMap[x, y + i];
-            //     if (mapTile == null || mapTile.ObjectNumber == 0) continue;
-            //
-            //     int objectNumber = mapTile.ObjectNumber;
-            //     if (objectNumber < 0 || objectNumber >= TileManager.ObjectInfos.Length) continue;
-            //
-            //     int objectHeight = TileManager.ObjectInfos[objectNumber].Indices.Length;
-            //     if (objectHeight <= i) continue;
-            //
-            //     int tile = TileManager.ObjectInfos[objectNumber].Indices[objectHeight - i - 1];
-            //     if (bitmap == null) bitmap = ImageRenderer.Singleton.GetObjectBitmap(tile);
-            //     else
-            //     {
-            //         //Graphics graphics = Graphics.FromImage(bitmap);
-            //         Bitmap tmpBitmap = ImageRenderer.Singleton.GetObjectBitmap(tile);
-            //         graphics.DrawImage(tmpBitmap, 0, 0);
-            //         //tmpBitmap.Dispose();
-            //         //graphics.Dispose();
-            //     }
-            // }
-            //
-            // graphics.Dispose();
-            // return bitmap;
-            
             if (!showObjects) return null;
             
             bitmap = new Bitmap(sizeModifier, sizeModifier);

--- a/MornaMapEditor/FormMinimap.Designer.cs
+++ b/MornaMapEditor/FormMinimap.Designer.cs
@@ -29,7 +29,7 @@
         private void InitializeComponent()
         {
             this.pnlImage = new System.Windows.Forms.PictureBox();
-            ((System.ComponentModel.ISupportInitialize)(this.pnlImage)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize) (this.pnlImage)).BeginInit();
             this.SuspendLayout();
             // 
             // pnlImage
@@ -60,20 +60,17 @@
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "FormMinimap";
+            this.ShowIcon = false;
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.Manual;
             this.Text = "Minimap";
             this.TopMost = true;
-            ((System.ComponentModel.ISupportInitialize)(this.pnlImage)).EndInit();
+            ((System.ComponentModel.ISupportInitialize) (this.pnlImage)).EndInit();
             this.ResumeLayout(false);
-
         }
-
-        #endregion
 
         internal System.Windows.Forms.PictureBox pnlImage;
 
-
-
+        #endregion
     }
 }

--- a/MornaMapEditor/Map.cs
+++ b/MornaMapEditor/Map.cs
@@ -162,41 +162,28 @@ namespace MornaMapEditor
             if (showTiles && tileBitmap != null && (!showObjects || objectBitmap == null))
             {
                 objectBitmap?.Dispose();
-                mapCache[x, y] = (Bitmap) tileBitmap.Clone();
+                mapCache[x, y] = tileBitmap;
             }
 
             // Only object
             else if (showObjects && objectBitmap != null && (!showTiles || tileBitmap == null))
             {
-                var renderedBitmap = new Bitmap(sizeModifier, sizeModifier);
-                var graphics = Graphics.FromImage(renderedBitmap);
-                //If only showing objects, make sure we have a background of dark green first
-                graphics.FillRectangle(Brushes.DarkGreen, x * sizeModifier, y * sizeModifier, sizeModifier, sizeModifier);
-                graphics.DrawImage(objectBitmap, x * sizeModifier, y * sizeModifier); //, 36, 36)
-                graphics.Dispose();
+                var renderedBitmap = ImageRenderer.Singleton.GetFilledObjectBitmap(objectBitmap, x, y);
                 tileBitmap?.Dispose();
                 objectBitmap.Dispose();
                 mapCache[x, y] = renderedBitmap;
             }
 
             // Both
-            else if (showTiles && showObjects)
+            else if (showTiles && showObjects && tileBitmap != null && objectBitmap != null)
             {
-                if (objectBitmap != null)
-                {
-                    var renderedBitmap = (Bitmap)tileBitmap.Clone();
-                    var tileGraphics = Graphics.FromImage(renderedBitmap);
-                    
-                    tileGraphics.DrawImage(objectBitmap, 0, 0);
-                    //tileGraphics.Dispose();
-                    tileGraphics.Dispose();
-                    tileBitmap.Dispose();
-                    objectBitmap.Dispose();
-                    mapCache[x, y] = renderedBitmap;
-                }
+                var renderedBitmap = ImageRenderer.Singleton.GetCombinedBitmap(tileBitmap, objectBitmap);
+                tileBitmap.Dispose();
+                objectBitmap.Dispose();
+                mapCache[x, y] = renderedBitmap;
             }
 
-            return (Bitmap) mapCache[x, y]?.Clone();
+            return mapCache[x, y];
         }
 
         private Bitmap GetObjectBitmap(int x, int y)
@@ -208,7 +195,7 @@ namespace MornaMapEditor
                 tilesWithPossibleObjects[i] = this[x, y + i];
             }
             
-            return this[x, y]?.RenderObjects(tilesWithPossibleObjects);
+            return ImageRenderer.Singleton.RenderObjects(tilesWithPossibleObjects);
         }
 
         public Bitmap GetRenderedMap(bool currentShowTiles, bool currentShowObjects)
@@ -235,7 +222,6 @@ namespace MornaMapEditor
                         if (renderedTile != null)
                         {
                             graphics.DrawImage(renderedTile, xPos, yPos);
-                            renderedTile.Dispose();
                         }
                         else
                             graphics.FillRectangle(Brushes.DarkGreen, xPos, yPos, sizeModifier, sizeModifier);

--- a/MornaMapEditor/Map.cs
+++ b/MornaMapEditor/Map.cs
@@ -12,7 +12,10 @@ namespace MornaMapEditor
         public Size Size { get; set; }
         public bool IsModified { get; set; }
         public bool IsEditable { get; set; }
-        public Dictionary<Point, Tile> MapData { get; private set; }
+        private Tile[,] mapData;
+        private Bitmap[,] mapCache;
+        private bool showTiles = true;
+        private bool showObjects = true;
 
         public Map(string mapPath)
         {
@@ -55,7 +58,7 @@ namespace MornaMapEditor
                     var tileNumber = reader.ReadUInt16();
                     var passable = reader.ReadUInt16();
                     var objectNumber = reader.ReadUInt16();
-                    MapData.Add(new Point(x, y), new Tile(tileNumber, Convert.ToBoolean(passable), objectNumber));
+                    mapData[x, y] = new Tile(tileNumber, Convert.ToBoolean(passable), objectNumber);
                 }
             }
 
@@ -106,41 +109,13 @@ namespace MornaMapEditor
             IsModified = false;
         }
 
-        private static void SaveBool(BinaryWriter writer, bool boolValue)
-        {
-            writer.Write((byte)0);
-            if (boolValue) writer.Write((byte) 1);
-            else writer.Write((byte)0);
-        }
-
-        private static void SaveInt(BinaryWriter writer, int intValue)
-        {
-            byte byte1, byte2;
-            IntTo2Bytes(intValue, out byte1, out byte2);
-            writer.Write(byte1);
-            writer.Write(byte2);
-        }
-
-        private static void IntTo2Bytes(int intValue, out byte byte1, out byte byte2)
-        {
-            byte1 = Convert.ToByte(intValue / 256);
-            byte2 = Convert.ToByte(intValue - (intValue / 256) * 256);
-        }
-
         public Tile this[int x, int y]
         {
-            get
-            {
-                Point point = new Point(x, y);
-                if (MapData.ContainsKey(point)) return MapData[point];
-                return null;
-            }
+            get => mapData[x, y];
             set
             {
                 if (!IsEditable) return;
-                Point point = new Point(x, y);
-                if (MapData.ContainsKey(point)) MapData.Remove(point);
-                MapData.Add(point, value);
+                mapData[x, y] = value;
                 IsModified = true;
             }
         }
@@ -154,7 +129,122 @@ namespace MornaMapEditor
         private void CreateEmptyMap(int width, int height)
         {
             Size = new Size(width, height);
-            MapData = new Dictionary<Point, Tile>();
+            mapData = new Tile[width,height];
+            mapCache = new Bitmap[width,height];
+        }
+
+        public Bitmap GetFullyRenderedTile(int x, int y, int sizeModifier, bool forceRenderEmpty, bool currentShowTiles, bool currentShowObjects)
+        {
+            var cachedTile = mapCache[x, y];
+            if (cachedTile?.Size.Width == sizeModifier && showTiles == currentShowTiles && showObjects == currentShowObjects)
+                return cachedTile;
+            showTiles = currentShowTiles;
+            showObjects = currentShowObjects;
+            var tileBitmap = !showTiles ? null : this[x, y]?.RenderTile();
+            var objectBitmap = GetObjectBitmap(x, y);
+            if (forceRenderEmpty)
+            {
+                Bitmap bitmapClear = new Bitmap(sizeModifier, sizeModifier);
+                Graphics gClear = Graphics.FromImage(bitmapClear);
+                gClear.Clear(Color.DarkGreen);
+
+                if (objectBitmap == null)
+                {
+                    if (tileBitmap == null) objectBitmap = bitmapClear;
+                    if (tileBitmap != null) objectBitmap = new Bitmap(sizeModifier, sizeModifier);
+                }
+                if (tileBitmap == null) tileBitmap = bitmapClear;
+                gClear.Dispose();
+                //bitmapClear.Dispose();
+            }
+
+            // Only tile
+            if (showTiles && tileBitmap != null && (!showObjects || objectBitmap == null))
+            {
+                objectBitmap?.Dispose();
+                mapCache[x, y] = (Bitmap) tileBitmap.Clone();
+            }
+
+            // Only object
+            else if (showObjects && objectBitmap != null && (!showTiles || tileBitmap == null))
+            {
+                var renderedBitmap = new Bitmap(sizeModifier, sizeModifier);
+                var graphics = Graphics.FromImage(renderedBitmap);
+                //If only showing objects, make sure we have a background of dark green first
+                graphics.FillRectangle(Brushes.DarkGreen, x * sizeModifier, y * sizeModifier, sizeModifier, sizeModifier);
+                graphics.DrawImage(objectBitmap, x * sizeModifier, y * sizeModifier); //, 36, 36)
+                graphics.Dispose();
+                tileBitmap?.Dispose();
+                objectBitmap.Dispose();
+                mapCache[x, y] = renderedBitmap;
+            }
+
+            // Both
+            else if (showTiles && showObjects)
+            {
+                if (objectBitmap != null)
+                {
+                    var renderedBitmap = (Bitmap)tileBitmap.Clone();
+                    var tileGraphics = Graphics.FromImage(renderedBitmap);
+                    
+                    tileGraphics.DrawImage(objectBitmap, 0, 0);
+                    //tileGraphics.Dispose();
+                    tileGraphics.Dispose();
+                    tileBitmap.Dispose();
+                    objectBitmap.Dispose();
+                    mapCache[x, y] = renderedBitmap;
+                }
+            }
+
+            return (Bitmap) mapCache[x, y]?.Clone();
+        }
+
+        private Bitmap GetObjectBitmap(int x, int y)
+        {
+            Tile[] tilesWithPossibleObjects = new Tile[12]; 
+            for (int i = 0; i < 12; i++)
+            {
+                if ((i + y) >= Size.Height) break;
+                tilesWithPossibleObjects[i] = this[x, y + i];
+            }
+            
+            return this[x, y]?.RenderObjects(tilesWithPossibleObjects);
+        }
+
+        public Bitmap GetRenderedMap(bool currentShowTiles, bool currentShowObjects)
+        {
+
+            showTiles = currentShowTiles;
+            showObjects = currentShowObjects;
+            
+            var sizeModifier = ImageRenderer.Singleton.sizeModifier;
+            
+            var returnImage = new Bitmap(Size.Width * sizeModifier, Size.Height * sizeModifier);
+            var graphics = Graphics.FromImage(returnImage);
+            graphics.Clear(Color.DarkGreen);
+            
+            if (showTiles || showObjects)
+            {
+                for (int x = 0; x < Size.Width; x++)
+                {
+                    for (int y = 0; y < Size.Height; y++)
+                    {
+                        var xPos = x * sizeModifier;
+                        var yPos = y * sizeModifier;
+                        var renderedTile = GetFullyRenderedTile(x, y, sizeModifier, false, showTiles, showObjects);
+                        if (renderedTile != null)
+                        {
+                            graphics.DrawImage(renderedTile, xPos, yPos);
+                            renderedTile.Dispose();
+                        }
+                        else
+                            graphics.FillRectangle(Brushes.DarkGreen, xPos, yPos, sizeModifier, sizeModifier);
+                    }
+                }
+            }
+
+            graphics.Dispose();
+            return returnImage;
         }
     }
 }

--- a/MornaMapEditor/MornaMapEditor.csproj
+++ b/MornaMapEditor/MornaMapEditor.csproj
@@ -88,6 +88,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ArchiveInfo.cs" />
+    <Compile Include="BatchConverter.cs" />
+    <Compile Include="BatchConverterDialog.cs" />
+    <Compile Include="BatchConverterDialog.Designer.cs" />
     <Compile Include="FormAbout.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -161,6 +164,7 @@
     <Compile Include="Tile.cs" />
     <Compile Include="TileManager.cs" />
     <Compile Include="TmpHelper.cs" />
+    <EmbeddedResource Include="BatchConverterDialog.resx" />
     <EmbeddedResource Include="FormAbout.resx">
       <DependentUpon>FormAbout.cs</DependentUpon>
     </EmbeddedResource>

--- a/MornaMapEditor/Tile.cs
+++ b/MornaMapEditor/Tile.cs
@@ -52,33 +52,7 @@ namespace MornaMapEditor
         {
             if (TileNumber <= 0) return null;
             if (TileNumber >= TileManager.Epf[0].max) return null;
-            return (Bitmap)ImageRenderer.Singleton.GetTileBitmap(TileNumber).Clone();
-        }
-
-        public Bitmap RenderObjects(Tile[] tilesWithPossibleObjects)
-        {
-            int sizeModifier = ImageRenderer.Singleton.sizeModifier;
-            Bitmap bitmap = new Bitmap(sizeModifier,sizeModifier);
-            Graphics graphics = Graphics.FromImage(bitmap);
-            for(int i = 0; i < 12; i++)
-            {
-                Tile tile = tilesWithPossibleObjects[i];
-                if (tile != null && tile.ObjectNumber != 0)
-                {
-                    int objectNumber = tile.ObjectNumber;
-                    if (objectNumber >= 0 && objectNumber < TileManager.ObjectInfos.Length)
-                    {
-                        int objectHeight = TileManager.ObjectInfos[objectNumber].Indices.Length;
-                        if (objectHeight > i)
-                        {
-                            int objTileNumber = TileManager.ObjectInfos[objectNumber].Indices[objectHeight - i - 1];
-                            graphics.DrawImage(ImageRenderer.Singleton.GetObjectBitmap(objTileNumber), 0, 0);
-                        }
-                    }
-                }
-            }
-            graphics.Dispose();
-            return bitmap;
+            return ImageRenderer.Singleton.GetTileBitmap(TileNumber);
         }
     }
 }

--- a/MornaMapEditor/Tile.cs
+++ b/MornaMapEditor/Tile.cs
@@ -1,4 +1,6 @@
-﻿namespace MornaMapEditor
+﻿using System.Drawing;
+
+namespace MornaMapEditor
 {
     public class Tile
     {
@@ -44,6 +46,39 @@
                 result = (result*397) ^ ObjectNumber;
                 return result;
             }
+        }
+
+        public Bitmap RenderTile()
+        {
+            if (TileNumber <= 0) return null;
+            if (TileNumber >= TileManager.Epf[0].max) return null;
+            return (Bitmap)ImageRenderer.Singleton.GetTileBitmap(TileNumber).Clone();
+        }
+
+        public Bitmap RenderObjects(Tile[] tilesWithPossibleObjects)
+        {
+            int sizeModifier = ImageRenderer.Singleton.sizeModifier;
+            Bitmap bitmap = new Bitmap(sizeModifier,sizeModifier);
+            Graphics graphics = Graphics.FromImage(bitmap);
+            for(int i = 0; i < 12; i++)
+            {
+                Tile tile = tilesWithPossibleObjects[i];
+                if (tile != null && tile.ObjectNumber != 0)
+                {
+                    int objectNumber = tile.ObjectNumber;
+                    if (objectNumber >= 0 && objectNumber < TileManager.ObjectInfos.Length)
+                    {
+                        int objectHeight = TileManager.ObjectInfos[objectNumber].Indices.Length;
+                        if (objectHeight > i)
+                        {
+                            int objTileNumber = TileManager.ObjectInfos[objectNumber].Indices[objectHeight - i - 1];
+                            graphics.DrawImage(ImageRenderer.Singleton.GetObjectBitmap(objTileNumber), 0, 0);
+                        }
+                    }
+                }
+            }
+            graphics.Dispose();
+            return bitmap;
         }
     }
 }


### PR DESCRIPTION
The main part of this work was to implement the capability of selecting a folder and having it convert all the maps inside to images. 

To facilitate this functionality rework of the rendering was required to allow it to be done outside of a Map Form. Once this change was implemented, more work was needed to make the rendering thread safe, this required relocation of the rendering logic to a single class where a single instance could be used for locking on the thread unsafe calls to graphics objects.